### PR TITLE
feat(self-signed): add Let's Encrypt support with HTTP-01 solver configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+copilot-instructions.md

--- a/self-signed/locals.tf
+++ b/self-signed/locals.tf
@@ -1,4 +1,24 @@
 locals {
+
+  default_solvers = {
+    http01 = {
+      http01 = {
+        ingress = {
+          class = "public"
+        }
+      }
+    }
+  }
+
+  use_default_solvers = {
+    http01 = var.use_default_http01_solver
+  }
+
+  solvers = concat(
+    [for each in ["http01"] : local.default_solvers[each] if local.use_default_solvers[each]],
+    var.custom_solver_configurations
+  )
+
   helm_values = [{
     cert-manager = {}
 
@@ -9,7 +29,10 @@ locals {
         tlsKey = base64encode(tls_private_key.root.private_key_pem)
       }
       letsencrypt = {
-        enabled = false
+        enabled = true
+        acme = {
+          solvers = local.solvers
+        }
       }
     }
   }]


### PR DESCRIPTION
## Description of the changes

This PR adds support for Let's Encrypt ACME challenges in the self-signed variant of the cert-manager module using HTTP-01 solver configuration.

**What was changed:**
- Added configurable HTTP-01 solver for ACME challenges in the self-signed variant
- Enabled Let's Encrypt issuer (previously disabled) in self-signed configuration
- Added default solver configuration with 'public' ingress class
- Added `copilot-instructions.md` to `.gitignore` to exclude AI agent instructions from version control

**Why these changes:**
The self-signed variant previously had Let's Encrypt support disabled. This change enables automatic certificate provisioning via Let's Encrypt while maintaining the self-signed CA fallback, providing more flexibility for users who want production-ready certificates in self-signed deployments.

The HTTP-01 solver configuration allows cert-manager to automatically validate domain ownership through HTTP challenges, making certificate issuance seamless.

## Breaking change

* [x] No
* [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
* [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

* [ ] KinD
* [ ] AKS (Azure)
* [ ] EKS (AWS)

_Note: This change affects only the self-signed variant configuration and requires testing to validate HTTP-01 solver functionality._